### PR TITLE
Fix core dump during the DESTRUCT phase

### DIFF
--- a/META.json
+++ b/META.json
@@ -37,6 +37,6 @@
       }
    },
    "release_status" : "stable",
-   "version" : "0.13",
+   "version" : "0.14",
    "x_serialization_backend" : "JSON::PP version 2.27400"
 }

--- a/META.yml
+++ b/META.yml
@@ -19,5 +19,5 @@ no_index:
     - inc
 requires:
   EV: '4'
-version: '0.13'
+version: '0.14'
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/lib/EV/Tarantool.pm
+++ b/lib/EV/Tarantool.pm
@@ -4,7 +4,7 @@ use 5.010;
 use strict;
 use warnings;
 
-our $VERSION = '0.13';
+our $VERSION = '0.14';
 
 use EV ();
 


### PR DESCRIPTION
There is an issue in the current version of the EV module. Calling EV::timer can cause core dumping. This patch adds workaround to avoid the issue.

Easiest way to reproduce the issue
```
perl -E 'use EV; sub DESTROY { EV::timer 0, 0, sub { } } $a = bless {}, "main"'
```